### PR TITLE
Yum robustness patch

### DIFF
--- a/hvp-db-c7.ks
+++ b/hvp-db-c7.ks
@@ -31,6 +31,10 @@
 # Note: to force custom AD further admin password add hvp_winadminpwd=mywinothersecret where mywinothersecret is the further AD admin user password
 # Note: to force custom keyboard layout add hvp_kblayout=cc where cc is the country code
 # Note: to force custom local timezone add hvp_timezone=VV where VV is the timezone specification
+# Note: to force custom Yum retries on failures add hvp_yum_retries=RR where RR is the number of retries
+# Note: to force custom Yum sleep time on failures add hvp_yum_sleep_time=SS where SS is the number of seconds between retries after each failure
+# Note: to force custom repo base URL for repo reponame add hvp_reponame_baseurl=HHHHH where HHHHH is the base URL (including variables like $releasever and $basearch)
+# Note: to force custom repo GPG key URL for repo reponame add hvp_reponame_gpgkey=GGGGG where GGGGG is the GPG key URL
 # Note: the default behaviour does not register fixed nic name-to-MAC mapping
 # Note: the default host naming uses the "My Little Pony" character name bigmcintosh
 # Note: the default addressing on connected networks is assumed to be 172.20.{10,12}.0/24 on {mgmt,lan}
@@ -52,6 +56,10 @@
 # Note: the default AD further admin user password is HVP_dem0
 # Note: the default keyboard layout is us
 # Note: the default local timezone is UTC
+# Note: the default number of retries after a Yum failure is 10
+# Note: the default sleep time between retries after a Yum failure is 10 seconds
+# Note: the default repo base URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
+# Note: the default repo GPG key URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
 # Note: to work around a known kernel commandline length limitation, all hvp_* parameters above can be omitted and proper default values (overriding the hardcoded ones) can be placed in Bash-syntax variables-definition files placed alongside the kickstart file - the name of the files retrieved and sourced (in the exact order) is: hvp_parameters.sh hvp_parameters_db.sh hvp_parameters_hh:hh:hh:hh:hh:hh.sh (where hh:hh:hh:hh:hh:hh is the MAC address of the nic used to retrieve the kickstart file)
 
 # Perform an installation (as opposed to an "upgrade")
@@ -105,11 +113,6 @@ selinux --enforcing
 
 # Disk configuration dynamically generated in pre section below
 %include /tmp/full-disk
-
-# Explicitly list provided repositories
-# Note: no additional repos setup - further packages/updates installed manually in post section
-#repo --name="CentOS"  --baseurl=cdrom:sr0 --cost=100
-#repo --name="HVP-mirror" --baseurl=https://dangerous.ovirt.life/hvp-repos/el7/centos
 
 # Packages list - package groups are preceded by an "@" sign - excluded packages by an "-" sign
 # Note: some virtualization technologies (Parallels, VirtualBox) require gcc, kernel-devel and dkms (from external repo) packages
@@ -241,6 +244,8 @@ unset winadmin_username
 unset winadmin_password
 unset keyboard_layout
 unset local_timezone
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Hardcoded defaults
 
@@ -248,6 +253,9 @@ nicmacfix="false"
 
 dbtype="postgresql"
 dbversion="9.6"
+
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 # Note: IP offsets below get used to automatically derive IP addresses
 # Note: no need to allow offset overriding from commandline if the IP address itself can be specified
@@ -908,32 +916,51 @@ fi
 # Create install source selection fragment
 # Note: we use a non-local (hd:) stage2 location as indicator of network boot
 given_stage2=$(sed -n -e 's/^.*inst\.stage2=\(\S*\).*$/\1/p' /proc/cmdline)
+# Define proper network source
+os_baseurl="http://mirror.centos.org/centos/7/os/x86_64"
+# Prefer custom OS repo URL, if any
+given_os_baseurl=$(sed -n -e 's/^.*hvp_base_baseurl=\(\S*\).*$/\1/p' /proc/cmdline)
+if [ -n "${given_os_baseurl}" ]; then
+	# Correctly detect an empty (disabled) repo URL
+	if [ "${given_os_baseurl}" = '""' -o "${given_os_baseurl}" = "''" ]; then
+		unset hvp_repo_baseurl['base']
+	else
+		hvp_repo_baseurl['base']="${given_os_baseurl}"
+	fi
+fi
+if [ -n "${hvp_repo_baseurl['base']}" ]; then
+	os_baseurl="${hvp_repo_baseurl['base']}"
+fi
 if echo "${given_stage2}" | grep -q '^hd:' ; then
 	# Detect use of NetInstall media
 	if [ -d /run/install/repo/repodata ]; then
-		# Note: we know that the local stage2 comes from a full DVD image (Packages repo included)
+		# Note: we know that the local stage2 comes from a Full/Minimal image (Packages repo included)
 		cat <<- EOF > /tmp/full-installsource
 		# Use the inserted optical media as in:
 		cdrom
 		# alternatively specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		#url --url https://dangerous.ovirt.life/hvp-repos/el7/os
+		# url --url http://mirror.centos.org/centos/7/os/x86_64
+		# Explicitly list further repositories
+		#repo --name="Local-Media"  --baseurl=cdrom:sr0 --cost=1001
+		# Note: network repo added anyway to avoid installation failures when using a Minimal image
+		repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
+
 		EOF
 	else
-		# Note: since we detected use of NetInstall media (no local repo) we use network install source from CentOS mirrors
-		given_stage2="http://mirror.centos.org/centos/7/os/x86_64"
+		# Note: since we detected use of NetInstall media (no local repo) we directly use a network install source
 		cat <<- EOF > /tmp/full-installsource
 		# Specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		url --url ${given_stage2}
+		url --url ${os_baseurl}
 		# alternatively use the inserted optical media as in:
-		#cdrom
+		# cdrom
 		EOF
 	fi
 else
-	# Note: we assume that a remote stage2 has been copied together with the full media content preserving the default DVD structure
+	# Note: we assume that a remote stage2 has been copied preserving the default Full/Minimal image structure
 	# TODO: we assume a HTTP/FTP area - add support for NFS
 	cat <<- EOF > /tmp/full-installsource
 	# Specify a NFS network share as in:
@@ -941,7 +968,10 @@ else
 	# or an HTTP/FTP area as in:
 	url --url ${given_stage2}
 	# alternatively use the inserted optical media as in:
-	#cdrom
+	# cdrom
+	# Explicitly list further repositories
+	# Note: network repo added anyway to avoid installation failures when a Minimal image has been copied
+	repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
 	EOF
 fi
 
@@ -1262,7 +1292,7 @@ done
 %post --log /dev/console
 ( # Run the entire post section as a subshell for logging purposes.
 
-script_version="2019030402"
+script_version="2019032601"
 
 # Report kickstart version for reference purposes
 logger -s -p "local7.info" -t "kickstart-post" "Kickstarting for $(cat /etc/system-release) - version ${script_version}"
@@ -1318,12 +1348,18 @@ unset nicmacfix
 unset dbtype
 unset dbversion
 unset notification_receiver
+unset yum_sleep_time
+unset yum_retries
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Define associative arrays
 declare -A network netmask network_base mtu
 declare -A domain_name
 declare -A reverse_domain_name
 declare -A test_ip
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 nicmacfix="false"
 
@@ -1332,7 +1368,32 @@ multi_instance_max="9"
 dbtype="postgresql"
 dbversion="9.6"
 
+yum_sleep_time="10"
+yum_retries="10"
+
 notification_receiver="monitoring@localhost"
+
+# A wrapper for Yum to make it more robust against network/mirror failures
+yum() {
+	local result
+	local retries_left
+
+	/usr/bin/yum "$@"
+	result=$?
+	retries_left=${yum_retries}
+
+	while [ ${result} -ne 0 -a ${retries_left} -gt 0 ]; do
+		sleep ${yum_sleep_time}
+		echo "Retrying yum operation (${retries_left} retries left at $(date '+%Y-%m-%d %H:%M:%S')) after failure (exit code ${result})" 1>&2
+		# Note: adding a complete cleanup before retrying
+		/usr/bin/yum clean all
+		/usr/bin/yum "$@"
+		result=$?
+		retries_left=$((retries_left - 1))
+	done
+
+	return ${result}
+}
 
 # Load configuration parameters files (generated in pre section above)
 ks_custom_frags="hvp_parameters.sh hvp_parameters_db.sh hvp_parameters_*:*.sh"
@@ -1396,6 +1457,18 @@ if [ -z "${dbversion}" -o "${dbtype}" != "postgresql" -a "${dbversion}" = "9.6" 
 	esac
 fi
 
+# Determine number of Yum retries on failure
+given_yum_retries=$(sed -n -e 's/^.*hvp_yum_retries=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_retries}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_retries="${given_yum_retries}"
+fi
+
+# Determine sleep time between Yum retries on failure
+given_yum_sleep_time=$(sed -n -e 's/^.*hvp_yum_sleep_time=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_sleep_time}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_sleep_time="${given_yum_sleep_time}"
+fi
+
 # Determine notification receiver email address
 given_receiver_email=$(sed -n -e "s/^.*hvp_receiver_email=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
 if [ -n "${given_receiver_email}" ]; then
@@ -1422,14 +1495,57 @@ ln -sf $rootdisk /dev/root
 rm -rf /var/cache/yum/*
 yum --enablerepo '*' clean all
 
-# Make YUM more robust in presence of network problems
-yum-config-manager --save --setopt='retries=30' --setopt='timeout=60' > /dev/null
+# Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: done here to cater for those repos already installed by default
+for repofile in /etc/yum.repos.d/*.repo; do
+	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
+		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
+		sed -i -e 's/^metalink/#metalink/g' "${repofile}"
+		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
+	fi
+done
+# Disable fastestmirror yum plugin too
+sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: done here to cater for those repos already installed by default
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Add YUM priorities plugin
 yum -y install yum-plugin-priorities
 
 # Add support for CentOS CR repository (to allow up-to-date upgrade later)
-# Note: a partially populated CR repo may introduce dependency-related errors - better to leave this to post-installation manual choices
+# Note: a partially populated CR repo may introduce dependency-related errors - better leave this to post-installation manual choices
 #yum-config-manager --enable cr > /dev/null
 
 # Add HVP custom repo
@@ -1451,6 +1567,7 @@ EOF
 chmod 644 /etc/yum.repos.d/webmin.repo
 
 # Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: repeated here to allow applying to further repos installed above
 for repofile in /etc/yum.repos.d/*.repo; do
 	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
 		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
@@ -1458,14 +1575,44 @@ for repofile in /etc/yum.repos.d/*.repo; do
 		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
 	fi
 done
-# Modify baseurl definitions to allow effective use of our proxy cache
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/7/>g' /etc/yum.repos.d/epel.repo
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/testing/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/testing/7/>g' /etc/yum.repos.d/epel-testing.repo
-# Disable fastestmirror yum plugin too
-sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: repeated here to allow applying to further repos installed above
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Enable use of delta rpms since we are not using a local mirror
-yum-config-manager --save --setopt='deltarpm=1' > /dev/null
+# Note: this may introduce HTTP 416 errors - better leave this to post-installation manual choices
+yum-config-manager --save --setopt='deltarpm=0' > /dev/null
 
 # Correctly initialize YUM cache again before actual bulk installations/upgrades
 # Note: following advice in https://access.redhat.com/articles/1320623

--- a/hvp-dc-c7.ks
+++ b/hvp-dc-c7.ks
@@ -35,6 +35,10 @@
 # Note: to force custom AD further admin password add hvp_winadminpwd=mywinothersecret where mywinothersecret is the further AD admin user password
 # Note: to force custom keyboard layout add hvp_kblayout=cc where cc is the country code
 # Note: to force custom local timezone add hvp_timezone=VV where VV is the timezone specification
+# Note: to force custom Yum retries on failures add hvp_yum_retries=RR where RR is the number of retries
+# Note: to force custom Yum sleep time on failures add hvp_yum_sleep_time=SS where SS is the number of seconds between retries after each failure
+# Note: to force custom repo base URL for repo reponame add hvp_reponame_baseurl=HHHHH where HHHHH is the base URL (including variables like $releasever and $basearch)
+# Note: to force custom repo GPG key URL for repo reponame add hvp_reponame_gpgkey=GGGGG where GGGGG is the GPG key URL
 # Note: the default behaviour does not register fixed nic name-to-MAC mapping
 # Note: the default host naming uses the "My Little Pony" character name spike
 # Note: the default addressing on connected networks is assumed to be 172.20.{10,12}.0/24 on {mgmt,lan}
@@ -60,6 +64,10 @@
 # Note: the default AD further admin user password is HVP_dem0
 # Note: the default keyboard layout is us
 # Note: the default local timezone is UTC
+# Note: the default number of retries after a Yum failure is 10
+# Note: the default sleep time between retries after a Yum failure is 10 seconds
+# Note: the default repo base URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
+# Note: the default repo GPG key URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
 # Note: to work around a known kernel commandline length limitation, all hvp_* parameters above can be omitted and proper default values (overriding the hardcoded ones) can be placed in Bash-syntax variables-definition files placed alongside the kickstart file - the name of the files retrieved and sourced (in the exact order) is: hvp_parameters.sh hvp_parameters_dc.sh hvp_parameters_hh:hh:hh:hh:hh:hh.sh (where hh:hh:hh:hh:hh:hh is the MAC address of the nic used to retrieve the kickstart file)
 
 # Perform an installation (as opposed to an "upgrade")
@@ -113,11 +121,6 @@ selinux --enforcing
 
 # Disk configuration dynamically generated in pre section below
 %include /tmp/full-disk
-
-# Explicitly list provided repositories
-# Note: no additional repos setup - further packages/updates installed manually in post section
-#repo --name="CentOS"  --baseurl=cdrom:sr0 --cost=100
-#repo --name="HVP-mirror" --baseurl=https://dangerous.ovirt.life/hvp-repos/el7/centos
 
 # Packages list - package groups are preceded by an "@" sign - excluded packages by an "-" sign
 # Note: some virtualization technologies (Parallels, VirtualBox) require gcc, kernel-devel and dkms (from external repo) packages
@@ -257,6 +260,8 @@ unset winadmin_username
 unset winadmin_password
 unset keyboard_layout
 unset local_timezone
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Hardcoded defaults
 
@@ -268,6 +273,9 @@ storage_name="discord"
 
 declare -A gluster_vol_name
 gluster_vol_name['unixshare']="unixshare"
+
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 # Note: IP offsets below get used to automatically derive IP addresses
 # Note: no need to allow offset overriding from commandline if the IP address itself can be specified
@@ -953,32 +961,51 @@ fi
 # Create install source selection fragment
 # Note: we use a non-local (hd:) stage2 location as indicator of network boot
 given_stage2=$(sed -n -e 's/^.*inst\.stage2=\(\S*\).*$/\1/p' /proc/cmdline)
+# Define proper network source
+os_baseurl="http://mirror.centos.org/centos/7/os/x86_64"
+# Prefer custom OS repo URL, if any
+given_os_baseurl=$(sed -n -e 's/^.*hvp_base_baseurl=\(\S*\).*$/\1/p' /proc/cmdline)
+if [ -n "${given_os_baseurl}" ]; then
+	# Correctly detect an empty (disabled) repo URL
+	if [ "${given_os_baseurl}" = '""' -o "${given_os_baseurl}" = "''" ]; then
+		unset hvp_repo_baseurl['base']
+	else
+		hvp_repo_baseurl['base']="${given_os_baseurl}"
+	fi
+fi
+if [ -n "${hvp_repo_baseurl['base']}" ]; then
+	os_baseurl="${hvp_repo_baseurl['base']}"
+fi
 if echo "${given_stage2}" | grep -q '^hd:' ; then
 	# Detect use of NetInstall media
 	if [ -d /run/install/repo/repodata ]; then
-		# Note: we know that the local stage2 comes from a full DVD image (Packages repo included)
+		# Note: we know that the local stage2 comes from a Full/Minimal image (Packages repo included)
 		cat <<- EOF > /tmp/full-installsource
 		# Use the inserted optical media as in:
 		cdrom
 		# alternatively specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		#url --url https://dangerous.ovirt.life/hvp-repos/el7/os
+		# url --url http://mirror.centos.org/centos/7/os/x86_64
+		# Explicitly list further repositories
+		#repo --name="Local-Media"  --baseurl=cdrom:sr0 --cost=1001
+		# Note: network repo added anyway to avoid installation failures when using a Minimal image
+		repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
+
 		EOF
 	else
-		# Note: since we detected use of NetInstall media (no local repo) we use network install source from CentOS mirrors
-		given_stage2="http://mirror.centos.org/centos/7/os/x86_64"
+		# Note: since we detected use of NetInstall media (no local repo) we directly use a network install source
 		cat <<- EOF > /tmp/full-installsource
 		# Specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		url --url ${given_stage2}
+		url --url ${os_baseurl}
 		# alternatively use the inserted optical media as in:
-		#cdrom
+		# cdrom
 		EOF
 	fi
 else
-	# Note: we assume that a remote stage2 has been copied together with the full media content preserving the default DVD structure
+	# Note: we assume that a remote stage2 has been copied preserving the default Full/Minimal image structure
 	# TODO: we assume a HTTP/FTP area - add support for NFS
 	cat <<- EOF > /tmp/full-installsource
 	# Specify a NFS network share as in:
@@ -986,7 +1013,10 @@ else
 	# or an HTTP/FTP area as in:
 	url --url ${given_stage2}
 	# alternatively use the inserted optical media as in:
-	#cdrom
+	# cdrom
+	# Explicitly list further repositories
+	# Note: network repo added anyway to avoid installation failures when a Minimal image has been copied
+	repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
 	EOF
 fi
 
@@ -1755,7 +1785,7 @@ done
 %post --log /dev/console
 ( # Run the entire post section as a subshell for logging purposes.
 
-script_version="2019030401"
+script_version="2019032601"
 
 # Report kickstart version for reference purposes
 logger -s -p "local7.info" -t "kickstart-post" "Kickstarting for $(cat /etc/system-release) - version ${script_version}"
@@ -1809,18 +1839,49 @@ unset test_ip
 unset multi_instance_max
 unset nicmacfix
 unset notification_receiver
+unset yum_sleep_time
+unset yum_retries
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Define associative arrays
 declare -A network netmask network_base mtu
 declare -A domain_name
 declare -A reverse_domain_name
 declare -A test_ip
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 nicmacfix="false"
 
 multi_instance_max="9"
 
+yum_sleep_time="10"
+yum_retries="10"
+
 notification_receiver="monitoring@localhost"
+
+# A wrapper for Yum to make it more robust against network/mirror failures
+yum() {
+	local result
+	local retries_left
+
+	/usr/bin/yum "$@"
+	result=$?
+	retries_left=${yum_retries}
+
+	while [ ${result} -ne 0 -a ${retries_left} -gt 0 ]; do
+		sleep ${yum_sleep_time}
+		echo "Retrying yum operation (${retries_left} retries left at $(date '+%Y-%m-%d %H:%M:%S')) after failure (exit code ${result})" 1>&2
+		# Note: adding a complete cleanup before retrying
+		/usr/bin/yum clean all
+		/usr/bin/yum "$@"
+		result=$?
+		retries_left=$((retries_left - 1))
+	done
+
+	return ${result}
+}
 
 # Load configuration parameters files (generated in pre section above)
 ks_custom_frags="hvp_parameters.sh hvp_parameters_dc.sh hvp_parameters_*:*.sh"
@@ -1851,6 +1912,18 @@ if echo "${given_multi_instance_max}" | grep -q '^[[:digit:]]\+$' ; then
 	multi_instance_max="${given_multi_instance_max}"
 fi
 
+# Determine number of Yum retries on failure
+given_yum_retries=$(sed -n -e 's/^.*hvp_yum_retries=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_retries}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_retries="${given_yum_retries}"
+fi
+
+# Determine sleep time between Yum retries on failure
+given_yum_sleep_time=$(sed -n -e 's/^.*hvp_yum_sleep_time=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_sleep_time}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_sleep_time="${given_yum_sleep_time}"
+fi
+
 # Determine notification receiver email address
 given_receiver_email=$(sed -n -e "s/^.*hvp_receiver_email=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
 if [ -n "${given_receiver_email}" ]; then
@@ -1877,14 +1950,57 @@ ln -sf $rootdisk /dev/root
 rm -rf /var/cache/yum/*
 yum --enablerepo '*' clean all
 
-# Make YUM more robust in presence of network problems
-yum-config-manager --save --setopt='retries=30' --setopt='timeout=60' > /dev/null
+# Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: done here to cater for those repos already installed by default
+for repofile in /etc/yum.repos.d/*.repo; do
+	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
+		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
+		sed -i -e 's/^metalink/#metalink/g' "${repofile}"
+		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
+	fi
+done
+# Disable fastestmirror yum plugin too
+sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: done here to cater for those repos already installed by default
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Add YUM priorities plugin
 yum -y install yum-plugin-priorities
 
 # Add support for CentOS CR repository (to allow up-to-date upgrade later)
-# Note: a partially populated CR repo may introduce dependency-related errors - better to leave this to post-installation manual choices
+# Note: a partially populated CR repo may introduce dependency-related errors - better leave this to post-installation manual choices
 #yum-config-manager --enable cr > /dev/null
 
 # Add HVP custom repo
@@ -1910,6 +2026,7 @@ EOF
 chmod 644 /etc/yum.repos.d/webmin.repo
 
 # Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: repeated here to allow applying to further repos installed above
 for repofile in /etc/yum.repos.d/*.repo; do
 	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
 		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
@@ -1917,14 +2034,44 @@ for repofile in /etc/yum.repos.d/*.repo; do
 		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
 	fi
 done
-# Modify baseurl definitions to allow effective use of our proxy cache
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/7/>g' /etc/yum.repos.d/epel.repo
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/testing/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/testing/7/>g' /etc/yum.repos.d/epel-testing.repo
-# Disable fastestmirror yum plugin too
-sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: repeated here to allow applying to further repos installed above
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Enable use of delta rpms since we are not using a local mirror
-yum-config-manager --save --setopt='deltarpm=1' > /dev/null
+# Note: this may introduce HTTP 416 errors - better leave this to post-installation manual choices
+yum-config-manager --save --setopt='deltarpm=0' > /dev/null
 
 # Correctly initialize YUM cache again before actual bulk installations/upgrades
 # Note: following advice in https://access.redhat.com/articles/1320623

--- a/hvp-pr-c7.ks
+++ b/hvp-pr-c7.ks
@@ -29,6 +29,10 @@
 # Note: to force custom AD further admin password add hvp_winadminpwd=mywinothersecret where mywinothersecret is the further AD admin user password
 # Note: to force custom keyboard layout add hvp_kblayout=cc where cc is the country code
 # Note: to force custom local timezone add hvp_timezone=VV where VV is the timezone specification
+# Note: to force custom Yum retries on failures add hvp_yum_retries=RR where RR is the number of retries
+# Note: to force custom Yum sleep time on failures add hvp_yum_sleep_time=SS where SS is the number of seconds between retries after each failure
+# Note: to force custom repo base URL for repo reponame add hvp_reponame_baseurl=HHHHH where HHHHH is the base URL (including variables like $releasever and $basearch)
+# Note: to force custom repo GPG key URL for repo reponame add hvp_reponame_gpgkey=GGGGG where GGGGG is the GPG key URL
 # Note: the default behaviour does not register fixed nic name-to-MAC mapping
 # Note: the default host naming uses the "My Little Pony" character name rainbowdash
 # Note: the default addressing on connected networks is assumed to be 172.20.{10,12}.0/24 on {mgmt,lan}
@@ -48,6 +52,10 @@
 # Note: the default AD further admin user password is HVP_dem0
 # Note: the default keyboard layout is us
 # Note: the default local timezone is UTC
+# Note: the default number of retries after a Yum failure is 10
+# Note: the default sleep time between retries after a Yum failure is 10 seconds
+# Note: the default repo base URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
+# Note: the default repo GPG key URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
 # Note: to work around a known kernel commandline length limitation, all hvp_* parameters above can be omitted and proper default values (overriding the hardcoded ones) can be placed in Bash-syntax variables-definition files placed alongside the kickstart file - the name of the files retrieved and sourced (in the exact order) is: hvp_parameters.sh hvp_parameters_pr.sh hvp_parameters_hh:hh:hh:hh:hh:hh.sh (where hh:hh:hh:hh:hh:hh is the MAC address of the nic used to retrieve the kickstart file)
 
 # Perform an installation (as opposed to an "upgrade")
@@ -101,11 +109,6 @@ selinux --enforcing
 
 # Disk configuration dynamically generated in pre section below
 %include /tmp/full-disk
-
-# Explicitly list provided repositories
-# Note: no additional repos setup - further packages/updates installed manually in post section
-#repo --name="CentOS"  --baseurl=cdrom:sr0 --cost=100
-#repo --name="HVP-mirror" --baseurl=https://dangerous.ovirt.life/hvp-repos/el7/centos
 
 # Packages list - package groups are preceded by an "@" sign - excluded packages by an "-" sign
 # Note: some virtualization technologies (Parallels, VirtualBox) require gcc, kernel-devel and dkms (from external repo) packages
@@ -235,10 +238,15 @@ unset winadmin_username
 unset winadmin_password
 unset keyboard_layout
 unset local_timezone
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Hardcoded defaults
 
 nicmacfix="false"
+
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 # Note: IP offsets below get used to automatically derive IP addresses
 # Note: no need to allow offset overriding from commandline if the IP address itself can be specified
@@ -872,32 +880,51 @@ fi
 # Create install source selection fragment
 # Note: we use a non-local (hd:) stage2 location as indicator of network boot
 given_stage2=$(sed -n -e 's/^.*inst\.stage2=\(\S*\).*$/\1/p' /proc/cmdline)
+# Define proper network source
+os_baseurl="http://mirror.centos.org/centos/7/os/x86_64"
+# Prefer custom OS repo URL, if any
+given_os_baseurl=$(sed -n -e 's/^.*hvp_base_baseurl=\(\S*\).*$/\1/p' /proc/cmdline)
+if [ -n "${given_os_baseurl}" ]; then
+	# Correctly detect an empty (disabled) repo URL
+	if [ "${given_os_baseurl}" = '""' -o "${given_os_baseurl}" = "''" ]; then
+		unset hvp_repo_baseurl['base']
+	else
+		hvp_repo_baseurl['base']="${given_os_baseurl}"
+	fi
+fi
+if [ -n "${hvp_repo_baseurl['base']}" ]; then
+	os_baseurl="${hvp_repo_baseurl['base']}"
+fi
 if echo "${given_stage2}" | grep -q '^hd:' ; then
 	# Detect use of NetInstall media
 	if [ -d /run/install/repo/repodata ]; then
-		# Note: we know that the local stage2 comes from a full DVD image (Packages repo included)
+		# Note: we know that the local stage2 comes from a Full/Minimal image (Packages repo included)
 		cat <<- EOF > /tmp/full-installsource
 		# Use the inserted optical media as in:
 		cdrom
 		# alternatively specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		#url --url https://dangerous.ovirt.life/hvp-repos/el7/os
+		# url --url http://mirror.centos.org/centos/7/os/x86_64
+		# Explicitly list further repositories
+		#repo --name="Local-Media"  --baseurl=cdrom:sr0 --cost=1001
+		# Note: network repo added anyway to avoid installation failures when using a Minimal image
+		repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
+
 		EOF
 	else
-		# Note: since we detected use of NetInstall media (no local repo) we use network install source from CentOS mirrors
-		given_stage2="http://mirror.centos.org/centos/7/os/x86_64"
+		# Note: since we detected use of NetInstall media (no local repo) we directly use a network install source
 		cat <<- EOF > /tmp/full-installsource
 		# Specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		url --url ${given_stage2}
+		url --url ${os_baseurl}
 		# alternatively use the inserted optical media as in:
-		#cdrom
+		# cdrom
 		EOF
 	fi
 else
-	# Note: we assume that a remote stage2 has been copied together with the full media content preserving the default DVD structure
+	# Note: we assume that a remote stage2 has been copied preserving the default Full/Minimal image structure
 	# TODO: we assume a HTTP/FTP area - add support for NFS
 	cat <<- EOF > /tmp/full-installsource
 	# Specify a NFS network share as in:
@@ -905,7 +932,10 @@ else
 	# or an HTTP/FTP area as in:
 	url --url ${given_stage2}
 	# alternatively use the inserted optical media as in:
-	#cdrom
+	# cdrom
+	# Explicitly list further repositories
+	# Note: network repo added anyway to avoid installation failures when a Minimal image has been copied
+	repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
 	EOF
 fi
 
@@ -1167,7 +1197,7 @@ done
 %post --log /dev/console
 ( # Run the entire post section as a subshell for logging purposes.
 
-script_version="2019030401"
+script_version="2019030261"
 
 # Report kickstart version for reference purposes
 logger -s -p "local7.info" -t "kickstart-post" "Kickstarting for $(cat /etc/system-release) - version ${script_version}"
@@ -1221,18 +1251,49 @@ unset test_ip
 unset multi_instance_max
 unset nicmacfix
 unset notification_receiver
+unset yum_sleep_time
+unset yum_retries
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Define associative arrays
 declare -A network netmask network_base mtu
 declare -A domain_name
 declare -A reverse_domain_name
 declare -A test_ip
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 nicmacfix="false"
 
 multi_instance_max="9"
 
+yum_sleep_time="10"
+yum_retries="10"
+
 notification_receiver="monitoring@localhost"
+
+# A wrapper for Yum to make it more robust against network/mirror failures
+yum() {
+	local result
+	local retries_left
+
+	/usr/bin/yum "$@"
+	result=$?
+	retries_left=${yum_retries}
+
+	while [ ${result} -ne 0 -a ${retries_left} -gt 0 ]; do
+		sleep ${yum_sleep_time}
+		echo "Retrying yum operation (${retries_left} retries left at $(date '+%Y-%m-%d %H:%M:%S')) after failure (exit code ${result})" 1>&2
+		# Note: adding a complete cleanup before retrying
+		/usr/bin/yum clean all
+		/usr/bin/yum "$@"
+		result=$?
+		retries_left=$((retries_left - 1))
+	done
+
+	return ${result}
+}
 
 # Load configuration parameters files (generated in pre section above)
 ks_custom_frags="hvp_parameters.sh hvp_parameters_pr.sh hvp_parameters_*:*.sh"
@@ -1263,6 +1324,18 @@ if echo "${given_multi_instance_max}" | grep -q '^[[:digit:]]\+$' ; then
 	multi_instance_max="${given_multi_instance_max}"
 fi
 
+# Determine number of Yum retries on failure
+given_yum_retries=$(sed -n -e 's/^.*hvp_yum_retries=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_retries}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_retries="${given_yum_retries}"
+fi
+
+# Determine sleep time between Yum retries on failure
+given_yum_sleep_time=$(sed -n -e 's/^.*hvp_yum_sleep_time=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_sleep_time}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_sleep_time="${given_yum_sleep_time}"
+fi
+
 # Determine notification receiver email address
 given_receiver_email=$(sed -n -e "s/^.*hvp_receiver_email=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
 if [ -n "${given_receiver_email}" ]; then
@@ -1289,14 +1362,57 @@ ln -sf $rootdisk /dev/root
 rm -rf /var/cache/yum/*
 yum --enablerepo '*' clean all
 
-# Make YUM more robust in presence of network problems
-yum-config-manager --save --setopt='retries=30' --setopt='timeout=60' > /dev/null
+# Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: done here to cater for those repos already installed by default
+for repofile in /etc/yum.repos.d/*.repo; do
+	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
+		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
+		sed -i -e 's/^metalink/#metalink/g' "${repofile}"
+		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
+	fi
+done
+# Disable fastestmirror yum plugin too
+sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: done here to cater for those repos already installed by default
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Add YUM priorities plugin
 yum -y install yum-plugin-priorities
 
 # Add support for CentOS CR repository (to allow up-to-date upgrade later)
-# Note: a partially populated CR repo may introduce dependency-related errors - better to leave this to post-installation manual choices
+# Note: a partially populated CR repo may introduce dependency-related errors - better leave this to post-installation manual choices
 #yum-config-manager --enable cr > /dev/null
 
 # Add HVP custom repo
@@ -1318,6 +1434,7 @@ EOF
 chmod 644 /etc/yum.repos.d/webmin.repo
 
 # Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: repeated here to allow applying to further repos installed above
 for repofile in /etc/yum.repos.d/*.repo; do
 	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
 		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
@@ -1325,14 +1442,44 @@ for repofile in /etc/yum.repos.d/*.repo; do
 		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
 	fi
 done
-# Modify baseurl definitions to allow effective use of our proxy cache
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/7/>g' /etc/yum.repos.d/epel.repo
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/testing/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/testing/7/>g' /etc/yum.repos.d/epel-testing.repo
-# Disable fastestmirror yum plugin too
-sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: repeated here to allow applying to further repos installed above
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Enable use of delta rpms since we are not using a local mirror
-yum-config-manager --save --setopt='deltarpm=1' > /dev/null
+# Note: this may introduce HTTP 416 errors - better leave this to post-installation manual choices
+yum-config-manager --save --setopt='deltarpm=0' > /dev/null
 
 # Correctly initialize YUM cache again before actual bulk installations/upgrades
 # Note: following advice in https://access.redhat.com/articles/1320623

--- a/hvp-vd-c7.ks
+++ b/hvp-vd-c7.ks
@@ -34,6 +34,10 @@
 # Note: to force custom AD further admin password add hvp_winadminpwd=mywinothersecret where mywinothersecret is the further AD admin user password
 # Note: to force custom keyboard layout add hvp_kblayout=cc where cc is the country code
 # Note: to force custom local timezone add hvp_timezone=VV where VV is the timezone specification
+# Note: to force custom Yum retries on failures add hvp_yum_retries=RR where RR is the number of retries
+# Note: to force custom Yum sleep time on failures add hvp_yum_sleep_time=SS where SS is the number of seconds between retries after each failure
+# Note: to force custom repo base URL for repo reponame add hvp_reponame_baseurl=HHHHH where HHHHH is the base URL (including variables like $releasever and $basearch)
+# Note: to force custom repo GPG key URL for repo reponame add hvp_reponame_gpgkey=GGGGG where GGGGG is the GPG key URL
 # Note: the default behaviour does not register fixed nic name-to-MAC mapping
 # Note: the default host naming uses the "My Little Pony" character name grannysmith
 # Note: the default addressing on connected networks is assumed to be 172.20.{10,12}.0/24 on {mgmt,lan}
@@ -58,6 +62,10 @@
 # Note: the default AD further admin user password is HVP_dem0
 # Note: the default keyboard layout is us
 # Note: the default local timezone is UTC
+# Note: the default number of retries after a Yum failure is 10
+# Note: the default sleep time between retries after a Yum failure is 10 seconds
+# Note: the default repo base URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
+# Note: the default repo GPG key URL for each required repo is that which is included into the default .repo file from the latest release package for each repo
 # Note: to work around a known kernel commandline length limitation, all hvp_* parameters above can be omitted and proper default values (overriding the hardcoded ones) can be placed in Bash-syntax variables-definition files placed alongside the kickstart file - the name of the files retrieved and sourced (in the exact order) is: hvp_parameters.sh hvp_parameters_vd.sh hvp_parameters_hh:hh:hh:hh:hh:hh.sh (where hh:hh:hh:hh:hh:hh is the MAC address of the nic used to retrieve the kickstart file)
 
 # Perform an installation (as opposed to an "upgrade")
@@ -111,11 +119,6 @@ selinux --enforcing
 
 # Disk configuration dynamically generated in pre section below
 %include /tmp/full-disk
-
-# Explicitly list provided repositories
-# Note: no additional repos setup - further packages/updates installed manually in post section
-#repo --name="CentOS"  --baseurl=cdrom:sr0 --cost=100
-#repo --name="HVP-mirror" --baseurl=https://dangerous.ovirt.life/hvp-repos/el7/centos
 
 # Packages list - package groups are preceded by an "@" sign - excluded packages by an "-" sign
 # Note: some virtualization technologies (Parallels, VirtualBox) require gcc, kernel-devel and dkms (from external repo) packages
@@ -268,6 +271,8 @@ unset winadmin_username
 unset winadmin_password
 unset keyboard_layout
 unset local_timezone
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Hardcoded defaults
 
@@ -281,6 +286,9 @@ web_name="cheerilee"
 
 detype="gnome"
 dedbtype="sqlite"
+
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 # Note: IP offsets below get used to automatically derive IP addresses
 # Note: no need to allow offset overriding from commandline if the IP address itself can be specified
@@ -951,32 +959,51 @@ fi
 # Create install source selection fragment
 # Note: we use a non-local (hd:) stage2 location as indicator of network boot
 given_stage2=$(sed -n -e 's/^.*inst\.stage2=\(\S*\).*$/\1/p' /proc/cmdline)
+# Define proper network source
+os_baseurl="http://mirror.centos.org/centos/7/os/x86_64"
+# Prefer custom OS repo URL, if any
+given_os_baseurl=$(sed -n -e 's/^.*hvp_base_baseurl=\(\S*\).*$/\1/p' /proc/cmdline)
+if [ -n "${given_os_baseurl}" ]; then
+	# Correctly detect an empty (disabled) repo URL
+	if [ "${given_os_baseurl}" = '""' -o "${given_os_baseurl}" = "''" ]; then
+		unset hvp_repo_baseurl['base']
+	else
+		hvp_repo_baseurl['base']="${given_os_baseurl}"
+	fi
+fi
+if [ -n "${hvp_repo_baseurl['base']}" ]; then
+	os_baseurl="${hvp_repo_baseurl['base']}"
+fi
 if echo "${given_stage2}" | grep -q '^hd:' ; then
 	# Detect use of NetInstall media
 	if [ -d /run/install/repo/repodata ]; then
-		# Note: we know that the local stage2 comes from a full DVD image (Packages repo included)
+		# Note: we know that the local stage2 comes from a Full/Minimal image (Packages repo included)
 		cat <<- EOF > /tmp/full-installsource
 		# Use the inserted optical media as in:
 		cdrom
 		# alternatively specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		#url --url https://dangerous.ovirt.life/hvp-repos/el7/os
+		# url --url http://mirror.centos.org/centos/7/os/x86_64
+		# Explicitly list further repositories
+		#repo --name="Local-Media"  --baseurl=cdrom:sr0 --cost=1001
+		# Note: network repo added anyway to avoid installation failures when using a Minimal image
+		repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
+
 		EOF
 	else
-		# Note: since we detected use of NetInstall media (no local repo) we use network install source from CentOS mirrors
-		given_stage2="http://mirror.centos.org/centos/7/os/x86_64"
+		# Note: since we detected use of NetInstall media (no local repo) we directly use a network install source
 		cat <<- EOF > /tmp/full-installsource
 		# Specify a NFS network share as in:
 		# nfs --opts=nolock --server NfsFqdnServerName --dir /path/to/CentOS/base/dir/copied/from/DVD/media
 		# or an HTTP/FTP area as in:
-		url --url ${given_stage2}
+		url --url ${os_baseurl}
 		# alternatively use the inserted optical media as in:
-		#cdrom
+		# cdrom
 		EOF
 	fi
 else
-	# Note: we assume that a remote stage2 has been copied together with the full media content preserving the default DVD structure
+	# Note: we assume that a remote stage2 has been copied preserving the default Full/Minimal image structure
 	# TODO: we assume a HTTP/FTP area - add support for NFS
 	cat <<- EOF > /tmp/full-installsource
 	# Specify a NFS network share as in:
@@ -984,7 +1011,10 @@ else
 	# or an HTTP/FTP area as in:
 	url --url ${given_stage2}
 	# alternatively use the inserted optical media as in:
-	#cdrom
+	# cdrom
+	# Explicitly list further repositories
+	# Note: network repo added anyway to avoid installation failures when a Minimal image has been copied
+	repo --name="CentOS-Mirror" --baseurl=${os_baseurl} --cost=1001
 	EOF
 fi
 
@@ -1222,7 +1252,7 @@ done
 %post --log /dev/console
 ( # Run the entire post section as a subshell for logging purposes.
 
-script_version="2019030401"
+script_version="2019032601"
 
 # Report kickstart version for reference purposes
 logger -s -p "local7.info" -t "kickstart-post" "Kickstarting for $(cat /etc/system-release) - version ${script_version}"
@@ -1279,12 +1309,18 @@ unset detype
 unset dedbtype
 unset db_name
 unset notification_receiver
+unset yum_sleep_time
+unset yum_retries
+unset hvp_repo_baseurl
+unset hvp_repo_gpgkey
 
 # Define associative arrays
 declare -A network netmask network_base mtu
 declare -A domain_name
 declare -A reverse_domain_name
 declare -A test_ip
+declare -A hvp_repo_baseurl
+declare -A hvp_repo_gpgkey
 
 nicmacfix="false"
 
@@ -1295,7 +1331,32 @@ db_name="bigmcintosh"
 detype="gnome"
 dedbtype="sqlite"
 
+yum_sleep_time="10"
+yum_retries="10"
+
 notification_receiver="monitoring@localhost"
+
+# A wrapper for Yum to make it more robust against network/mirror failures
+yum() {
+	local result
+	local retries_left
+
+	/usr/bin/yum "$@"
+	result=$?
+	retries_left=${yum_retries}
+
+	while [ ${result} -ne 0 -a ${retries_left} -gt 0 ]; do
+		sleep ${yum_sleep_time}
+		echo "Retrying yum operation (${retries_left} retries left at $(date '+%Y-%m-%d %H:%M:%S')) after failure (exit code ${result})" 1>&2
+		# Note: adding a complete cleanup before retrying
+		/usr/bin/yum clean all
+		/usr/bin/yum "$@"
+		result=$?
+		retries_left=$((retries_left - 1))
+	done
+
+	return ${result}
+}
 
 # Load configuration parameters files (generated in pre section above)
 ks_custom_frags="hvp_parameters.sh hvp_parameters_vd.sh hvp_parameters_*:*.sh"
@@ -1348,6 +1409,18 @@ case "${given_dedbtype}" in
 		;;
 esac
 
+# Determine number of Yum retries on failure
+given_yum_retries=$(sed -n -e 's/^.*hvp_yum_retries=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_retries}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_retries="${given_yum_retries}"
+fi
+
+# Determine sleep time between Yum retries on failure
+given_yum_sleep_time=$(sed -n -e 's/^.*hvp_yum_sleep_time=\(\S*\).*$/\1/p' /proc/cmdline)
+if echo "${given_yum_sleep_time}" | grep -q '^[[:digit:]]\+$' ; then
+	yum_sleep_time="${given_yum_sleep_time}"
+fi
+
 # Determine notification receiver email address
 given_receiver_email=$(sed -n -e "s/^.*hvp_receiver_email=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
 if [ -n "${given_receiver_email}" ]; then
@@ -1377,14 +1450,57 @@ yum -y install yum-plugin-priorities
 rm -rf /var/cache/yum/*
 yum --enablerepo '*' clean all
 
-# Make YUM more robust in presence of network problems
-yum-config-manager --save --setopt='retries=30' --setopt='timeout=60' > /dev/null
+# Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: done here to cater for those repos already installed by default
+for repofile in /etc/yum.repos.d/*.repo; do
+	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
+		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
+		sed -i -e 's/^metalink/#metalink/g' "${repofile}"
+		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
+	fi
+done
+# Disable fastestmirror yum plugin too
+sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: done here to cater for those repos already installed by default
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Add YUM priorities plugin
 yum -y install yum-plugin-priorities
 
 # Add support for CentOS CR repository (to allow up-to-date upgrade later)
-# Note: a partially populated CR repo may introduce dependency-related errors - better to leave this to post-installation manual choices
+# Note: a partially populated CR repo may introduce dependency-related errors - better leave this to post-installation manual choices
 #yum-config-manager --enable cr > /dev/null
 
 # Add HVP custom repo
@@ -1414,6 +1530,7 @@ yum-config-manager --enable x2go-saimaa-epel > /dev/null
 yum-config-manager --save --setopt='x2go-saimaa-epel.priority=50' > /dev/null
 
 # Comment out mirrorlist directives and uncomment the baseurl ones to make better use of proxy caches
+# Note: repeated here to allow applying to further repos installed above
 for repofile in /etc/yum.repos.d/*.repo; do
 	if egrep -q '^(mirrorlist|metalink)' "${repofile}"; then
 		sed -i -e 's/^mirrorlist/#mirrorlist/g' "${repofile}"
@@ -1421,14 +1538,44 @@ for repofile in /etc/yum.repos.d/*.repo; do
 		sed -i -e 's/^#baseurl/baseurl/g' "${repofile}"
 	fi
 done
-# Modify baseurl definitions to allow effective use of our proxy cache
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/7/>g' /etc/yum.repos.d/epel.repo
-sed -i -e 's>http://download.fedoraproject.org/pub/epel/testing/7/>http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/testing/7/>g' /etc/yum.repos.d/epel-testing.repo
-# Disable fastestmirror yum plugin too
-sed -i -e 's/^enabled.*/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# Allow specifying custom base URLs for repositories and GPG keys
+# Note: repeated here to allow applying to further repos installed above
+for repo_name in $(yum repolist all -v 2>/dev/null | awk '/Repo-id/ {print $3}' | sed -e 's>/.*$>>g'); do
+	# Take URLs from parameters files or hardcoded defaults
+	repo_baseurl="${hvp_repo_baseurl[${repo_name}]}"
+	repo_gpgkey="${hvp_repo_gpgkey[${repo_name}]}"
+	# Take URLs from kernel commandline
+	given_repo_baseurl=$(sed -n -e "s/^.*hvp_${repo_name}_baseurl=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_baseurl}" ]; then
+		# Correctly detect an empty (disabled) repo URL
+		if [ "${given_repo_baseurl}" = '""' -o "${given_repo_baseurl}" = "''" ]; then
+			unset repo_baseurl
+		else
+			repo_baseurl="${given_repo_baseurl}"
+		fi
+	fi
+	given_repo_gpgkey=$(sed -n -e "s/^.*hvp_${repo_name}_gpgkey=\\(\\S*\\).*\$/\\1/p" /proc/cmdline)
+	if [ -n "${given_repo_gpgkey}" ]; then
+		# Correctly detect an empty (disabled) gpgkey URL
+		if [ "${given_repo_gpgkey}" = '""' -o "${given_repo_gpgkey}" = "''" ]; then
+			unset repo_gpgkey
+		else
+			repo_gpgkey="${given_repo_gpgkey}"
+		fi
+	fi
+	# Force any custom URLs
+	if [ -n "${repo_baseurl}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.baseurl=${repo_baseurl}" > /dev/null
+	fi
+	if [ -n "${repo_gpgkey}" ]; then
+		yum-config-manager --save --setopt="${repo_name}.gpgkey=${repo_gpgkey}" > /dev/null
+	fi
+done
 
 # Enable use of delta rpms since we are not using a local mirror
-yum-config-manager --save --setopt='deltarpm=1' > /dev/null
+# Note: this may introduce HTTP 416 errors - better leave this to post-installation manual choices
+yum-config-manager --save --setopt='deltarpm=0' > /dev/null
 
 # Correctly initialize YUM cache again before actual bulk installations/upgrades
 # Note: following advice in https://access.redhat.com/articles/1320623

--- a/hvp_parameters_db.sh
+++ b/hvp_parameters_db.sh
@@ -52,3 +52,13 @@ keyboard_layout="us"
 local_timezone="UTC"
 
 notification_receiver="monitoring@localhost"
+
+yum_sleep_time="10"
+yum_retries="10"
+
+# Note: default base and GPG-key values for repos are those inside .repo files - reported here as an example
+#hvp_repo_baseurl['base']='http://centos.mirror.garr.it/centos/$releasever/os/$basearch/'
+#hvp_repo_baseurl['updates']='http://centos.mirror.garr.it/centos/$releasever/updates/$basearch/'
+#hvp_repo_baseurl['extras']='http://centos.mirror.garr.it/centos/$releasever/extras/$basearch/'
+#hvp_repo_baseurl['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/$releasever/$basearch/'
+#hvp_repo_gpgkey['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/RPM-GPG-KEY-EPEL-$releasever'

--- a/hvp_parameters_dc.sh
+++ b/hvp_parameters_dc.sh
@@ -63,3 +63,13 @@ keyboard_layout="us"
 local_timezone="UTC"
 
 notification_receiver="monitoring@localhost"
+
+yum_sleep_time="10"
+yum_retries="10"
+
+# Note: default base and GPG-key values for repos are those inside .repo files - reported here as an example
+#hvp_repo_baseurl['base']='http://centos.mirror.garr.it/centos/$releasever/os/$basearch/'
+#hvp_repo_baseurl['updates']='http://centos.mirror.garr.it/centos/$releasever/updates/$basearch/'
+#hvp_repo_baseurl['extras']='http://centos.mirror.garr.it/centos/$releasever/extras/$basearch/'
+#hvp_repo_baseurl['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/$releasever/$basearch/'
+#hvp_repo_gpgkey['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/RPM-GPG-KEY-EPEL-$releasever'

--- a/hvp_parameters_pr.sh
+++ b/hvp_parameters_pr.sh
@@ -48,3 +48,13 @@ keyboard_layout="us"
 local_timezone="UTC"
 
 notification_receiver="monitoring@localhost"
+
+yum_sleep_time="10"
+yum_retries="10"
+
+# Note: default base and GPG-key values for repos are those inside .repo files - reported here as an example
+#hvp_repo_baseurl['base']='http://centos.mirror.garr.it/centos/$releasever/os/$basearch/'
+#hvp_repo_baseurl['updates']='http://centos.mirror.garr.it/centos/$releasever/updates/$basearch/'
+#hvp_repo_baseurl['extras']='http://centos.mirror.garr.it/centos/$releasever/extras/$basearch/'
+#hvp_repo_baseurl['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/$releasever/$basearch/'
+#hvp_repo_gpgkey['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/RPM-GPG-KEY-EPEL-$releasever'

--- a/hvp_parameters_vd.sh
+++ b/hvp_parameters_vd.sh
@@ -57,3 +57,13 @@ keyboard_layout="us"
 local_timezone="UTC"
 
 notification_receiver="monitoring@localhost"
+
+yum_sleep_time="10"
+yum_retries="10"
+
+# Note: default base and GPG-key values for repos are those inside .repo files - reported here as an example
+#hvp_repo_baseurl['base']='http://centos.mirror.garr.it/centos/$releasever/os/$basearch/'
+#hvp_repo_baseurl['updates']='http://centos.mirror.garr.it/centos/$releasever/updates/$basearch/'
+#hvp_repo_baseurl['extras']='http://centos.mirror.garr.it/centos/$releasever/extras/$basearch/'
+#hvp_repo_baseurl['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/$releasever/$basearch/'
+#hvp_repo_gpgkey['epel']='http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/RPM-GPG-KEY-EPEL-$releasever'


### PR DESCRIPTION
Already done but not completely tested: 
- Allow to customize base URL and GPG key URL for each repo (excluding bad mirrors or selecting private ones)
- Add yum command wrapper (available only during %post phase number 1) to retry yum ops on failure (with customizable sleep time and number of retries)
- Use custom base URL as OS repo during a NetInstall-based installation
- Disable use of RPM deltas
